### PR TITLE
basic GB03 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The GB01 is a small Bluetooth thermal printer that uses receipt paper.
 I don't know if it's been built into other cases, but mine kind of looks like a cat.
 You can tell it's a GB01 because it shows up as a Bluetooth device called "GB01" when you scan for it.
 
+Additionally supports the GB03 printer.
+
 This script takes a filename as its only required parameter. 
 It will attempt to load the file as an image, 
 connect to the first Bluetooth low energy device called "GB01" it finds,

--- a/gb01print.py
+++ b/gb01print.py
@@ -111,7 +111,7 @@ def detect_printer(detected, advertisement_data):
         cut_addr = detected.address.replace(":", "")[-(len(address)):].upper()
         if cut_addr != address:
             return
-    if detected.name == 'GB01':
+    if detected.name in ['GB01','GB03']:
         device = detected
 
 


### PR DESCRIPTION
Tested on GB03, which appears to be an identical printer but reports a different model. Works perfectly as is, so this PR just adds a note in the readme and conditional support for the model check in code.